### PR TITLE
Feature/k8s modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # LonganPi-3H-SDK
 Scripts and blobs for LonganPi 3H image build.
 
-Build arm-trusted-firmware
+1. Build arm-trusted-firmware
 ```shell
 sh mkatf.sh
 ```
 
-Build uboot
+2. Build uboot
 ```shell
 sh mkuboot.sh
 ```
 
-Build kernel
+3. Build kernel
 ```shell
 sh mklinux.sh
 ```
 
-Build rootfs
+4. Build rootfs debian
 ```shell
 sh mkrootfs.sh
+# or .. sh mkrootfs-ubuntu.sh
 ```
+

--- a/find-ubuntu-mirrors.sh
+++ b/find-ubuntu-mirrors.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## credit to: https://gist.github.com/mtnygard/9cfef214c6942171a578da11741a9d85#file-find_mirrors-sh
+
+# URL of the Launchpad mirror list
+MIRROR_LIST=https://launchpad.net/ubuntu/+archivemirrors
+
+# Set to the architecture you're looking for (e.g., amd64, i386, arm64, armhf, armel, powerpc, ...).
+# See https://wiki.ubuntu.com/UbuntuDevelopment/PackageArchive#Architectures
+ARCH=$1
+# Set to the Ubuntu distribution you need (e.g., precise, saucy, trusty, ...)
+# See https://wiki.ubuntu.com/DevelopmentCodeNames
+DIST=$2
+# Set to the repository you're looking for (main, restricted, universe, multiverse)
+# See https://help.ubuntu.com/community/Repositories/Ubuntu
+REPO=$3
+
+# First, we retrieve the Launchpad mirror list, and massage it to obtain a newline-separated list of HTTP mirrors
+for url in $(curl -s $MIRROR_LIST | grep -Po 'http://.*(?=">http</a>)'); do
+  # If you like some output while the script is running (feel free to comment out the following line)
+  echo "Processing $url..."
+  # retrieve the header for the URL $url/dists/$DIST/$REPO/binary-$ARCH/; check if status code is of the form 2.. or 3..
+  curl -s --head $url/dists/$DIST/$REPO/binary-$ARCH/ | head -n 1 | grep -q "HTTP/1.[01] [23].."
+  # if successful, output the URL
+  [ $? -eq "0" ] && echo "FOUND: $url"
+done

--- a/linux/ipv6-netfilter-k8s.patch
+++ b/linux/ipv6-netfilter-k8s.patch
@@ -1,0 +1,667 @@
+From 647d8bbdda5967ad29b0f6620a7be19a1fbd93a8 Mon Sep 17 00:00:00 2001
+From: elasticdotventures <brianh@elastic.ventures>
+Date: Mon, 22 Jan 2024 05:52:50 +0000
+Subject: [PATCH] .
+
+---
+ arch/arm64/configs/longanpi_3h_defconfig | 549 ++++++++++++++++++++++-
+ 1 file changed, 543 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm64/configs/longanpi_3h_defconfig b/arch/arm64/configs/longanpi_3h_defconfig
+index e0568ea4bbe3..435afa36da42 100644
+--- a/arch/arm64/configs/longanpi_3h_defconfig
++++ b/arch/arm64/configs/longanpi_3h_defconfig
+@@ -535,7 +535,8 @@ CONFIG_ARM_ALLWINNER_SUN50I_CPUFREQ_NVMEM=y
+ # end of CPU Power Management
+ 
+ CONFIG_HAVE_KVM=y
+-# CONFIG_VIRTUALIZATION is not set
++CONFIG_VIRTUALIZATION=y
++# CONFIG_KVM is not set
+ 
+ #
+ # General architecture-dependent options
+@@ -823,6 +824,9 @@ CONFIG_LOCK_MM_AND_FIND_VMA=y
+ # end of Memory Management options
+ 
+ CONFIG_NET=y
++CONFIG_NET_INGRESS=y
++CONFIG_NET_EGRESS=y
++CONFIG_SKB_EXTENSIONS=y
+ 
+ #
+ # Networking options
+@@ -842,13 +846,16 @@ CONFIG_INET=y
+ # CONFIG_IP_PNP is not set
+ # CONFIG_NET_IPIP is not set
+ # CONFIG_NET_IPGRE_DEMUX is not set
++CONFIG_NET_IP_TUNNEL=m
+ # CONFIG_SYN_COOKIES is not set
+ # CONFIG_NET_IPVTI is not set
+ # CONFIG_NET_FOU is not set
++# CONFIG_NET_FOU_IP_TUNNELS is not set
+ # CONFIG_INET_AH is not set
+ # CONFIG_INET_ESP is not set
+ # CONFIG_INET_IPCOMP is not set
+ CONFIG_INET_TABLE_PERTURB_ORDER=16
++CONFIG_INET_TUNNEL=m
+ # CONFIG_INET_DIAG is not set
+ CONFIG_TCP_CONG_ADVANCED=y
+ CONFIG_TCP_CONG_BIC=m
+@@ -870,13 +877,138 @@ CONFIG_TCP_CONG_HTCP=m
+ CONFIG_DEFAULT_CUBIC=y
+ # CONFIG_DEFAULT_RENO is not set
+ CONFIG_DEFAULT_TCP_CONG="cubic"
+-# CONFIG_TCP_AO is not set
+ # CONFIG_TCP_MD5SIG is not set
+-# CONFIG_IPV6 is not set
++CONFIG_IPV6=m
++# CONFIG_IPV6_ROUTER_PREF is not set
++# CONFIG_IPV6_OPTIMISTIC_DAD is not set
++# CONFIG_INET6_AH is not set
++# CONFIG_INET6_ESP is not set
++# CONFIG_INET6_IPCOMP is not set
++# CONFIG_IPV6_MIP6 is not set
++# CONFIG_IPV6_ILA is not set
++# CONFIG_IPV6_VTI is not set
++CONFIG_IPV6_SIT=m
++# CONFIG_IPV6_SIT_6RD is not set
++CONFIG_IPV6_NDISC_NODETYPE=y
++# CONFIG_IPV6_TUNNEL is not set
++# CONFIG_IPV6_MULTIPLE_TABLES is not set
++# CONFIG_IPV6_MROUTE is not set
++# CONFIG_IPV6_SEG6_LWTUNNEL is not set
++# CONFIG_IPV6_SEG6_HMAC is not set
++# CONFIG_IPV6_RPL_LWTUNNEL is not set
++# CONFIG_IPV6_IOAM6_LWTUNNEL is not set
+ # CONFIG_MPTCP is not set
+ # CONFIG_NETWORK_SECMARK is not set
+ # CONFIG_NETWORK_PHY_TIMESTAMPING is not set
+-# CONFIG_NETFILTER is not set
++CONFIG_NETFILTER=y
++CONFIG_NETFILTER_ADVANCED=y
++CONFIG_BRIDGE_NETFILTER=m
++
++#
++# Core Netfilter Configuration
++#
++CONFIG_NETFILTER_INGRESS=y
++CONFIG_NETFILTER_EGRESS=y
++CONFIG_NETFILTER_NETLINK=m
++CONFIG_NETFILTER_FAMILY_BRIDGE=y
++# CONFIG_NETFILTER_NETLINK_ACCT is not set
++# CONFIG_NETFILTER_NETLINK_QUEUE is not set
++# CONFIG_NETFILTER_NETLINK_LOG is not set
++# CONFIG_NETFILTER_NETLINK_OSF is not set
++# CONFIG_NF_CONNTRACK is not set
++# CONFIG_NF_LOG_SYSLOG is not set
++# CONFIG_NF_TABLES is not set
++# CONFIG_NETFILTER_XTABLES is not set
++# end of Core Netfilter Configuration
++
++CONFIG_IP_SET=m
++CONFIG_IP_SET_MAX=256
++# CONFIG_IP_SET_BITMAP_IP is not set
++# CONFIG_IP_SET_BITMAP_IPMAC is not set
++# CONFIG_IP_SET_BITMAP_PORT is not set
++# CONFIG_IP_SET_HASH_IP is not set
++# CONFIG_IP_SET_HASH_IPMARK is not set
++# CONFIG_IP_SET_HASH_IPPORT is not set
++# CONFIG_IP_SET_HASH_IPPORTIP is not set
++# CONFIG_IP_SET_HASH_IPPORTNET is not set
++# CONFIG_IP_SET_HASH_IPMAC is not set
++# CONFIG_IP_SET_HASH_MAC is not set
++# CONFIG_IP_SET_HASH_NETPORTNET is not set
++# CONFIG_IP_SET_HASH_NET is not set
++# CONFIG_IP_SET_HASH_NETNET is not set
++# CONFIG_IP_SET_HASH_NETPORT is not set
++# CONFIG_IP_SET_HASH_NETIFACE is not set
++# CONFIG_IP_SET_LIST_SET is not set
++CONFIG_IP_VS=m
++# CONFIG_IP_VS_IPV6 is not set
++# CONFIG_IP_VS_DEBUG is not set
++CONFIG_IP_VS_TAB_BITS=12
++
++#
++# IPVS transport protocol load balancing support
++#
++# CONFIG_IP_VS_PROTO_TCP is not set
++# CONFIG_IP_VS_PROTO_UDP is not set
++# CONFIG_IP_VS_PROTO_ESP is not set
++# CONFIG_IP_VS_PROTO_AH is not set
++# CONFIG_IP_VS_PROTO_SCTP is not set
++
++#
++# IPVS scheduler
++#
++# CONFIG_IP_VS_RR is not set
++# CONFIG_IP_VS_WRR is not set
++# CONFIG_IP_VS_LC is not set
++# CONFIG_IP_VS_WLC is not set
++# CONFIG_IP_VS_FO is not set
++# CONFIG_IP_VS_OVF is not set
++# CONFIG_IP_VS_LBLC is not set
++# CONFIG_IP_VS_LBLCR is not set
++# CONFIG_IP_VS_DH is not set
++# CONFIG_IP_VS_SH is not set
++# CONFIG_IP_VS_MH is not set
++# CONFIG_IP_VS_SED is not set
++# CONFIG_IP_VS_NQ is not set
++# CONFIG_IP_VS_TWOS is not set
++
++#
++# IPVS SH scheduler
++#
++CONFIG_IP_VS_SH_TAB_BITS=8
++
++#
++# IPVS MH scheduler
++#
++CONFIG_IP_VS_MH_TAB_INDEX=12
++
++#
++# IPVS application helper
++#
++
++#
++# IP: Netfilter Configuration
++#
++# CONFIG_NF_SOCKET_IPV4 is not set
++# CONFIG_NF_TPROXY_IPV4 is not set
++# CONFIG_NF_DUP_IPV4 is not set
++# CONFIG_NF_LOG_ARP is not set
++# CONFIG_NF_LOG_IPV4 is not set
++# CONFIG_NF_REJECT_IPV4 is not set
++# CONFIG_IP_NF_IPTABLES is not set
++# CONFIG_IP_NF_ARPTABLES is not set
++# end of IP: Netfilter Configuration
++
++#
++# IPv6: Netfilter Configuration
++#
++CONFIG_NF_SOCKET_IPV6=m
++# CONFIG_NF_TPROXY_IPV6 is not set
++# CONFIG_NF_DUP_IPV6 is not set
++# CONFIG_NF_REJECT_IPV6 is not set
++# CONFIG_NF_LOG_IPV6 is not set
++# CONFIG_IP6_NF_IPTABLES is not set
++# end of IPv6: Netfilter Configuration
++
+ # CONFIG_BPFILTER is not set
+ # CONFIG_IP_DCCP is not set
+ # CONFIG_IP_SCTP is not set
+@@ -884,14 +1016,20 @@ CONFIG_DEFAULT_TCP_CONG="cubic"
+ # CONFIG_TIPC is not set
+ # CONFIG_ATM is not set
+ # CONFIG_L2TP is not set
+-# CONFIG_BRIDGE is not set
++CONFIG_STP=m
++CONFIG_BRIDGE=m
++CONFIG_BRIDGE_IGMP_SNOOPING=y
++# CONFIG_BRIDGE_MRP is not set
++# CONFIG_BRIDGE_CFM is not set
+ # CONFIG_NET_DSA is not set
+ # CONFIG_VLAN_8021Q is not set
++CONFIG_LLC=m
+ # CONFIG_LLC2 is not set
+ # CONFIG_ATALK is not set
+ # CONFIG_X25 is not set
+ # CONFIG_LAPB is not set
+ # CONFIG_PHONET is not set
++# CONFIG_6LOWPAN is not set
+ # CONFIG_IEEE802154 is not set
+ # CONFIG_NET_SCHED is not set
+ # CONFIG_DCB is not set
+@@ -1006,6 +1144,8 @@ CONFIG_RFKILL_GPIO=y
+ # CONFIG_PSAMPLE is not set
+ # CONFIG_NET_IFE is not set
+ # CONFIG_LWTUNNEL is not set
++CONFIG_DST_CACHE=y
++CONFIG_GRO_CELLS=y
+ CONFIG_NET_SELFTESTS=y
+ CONFIG_PAGE_POOL=y
+ # CONFIG_PAGE_POOL_STATS is not set
+@@ -1724,6 +1864,7 @@ CONFIG_POWER_RESET_SYSCON=y
+ # CONFIG_NVMEM_REBOOT_MODE is not set
+ CONFIG_POWER_SUPPLY=y
+ # CONFIG_POWER_SUPPLY_DEBUG is not set
++# CONFIG_GENERIC_ADC_BATTERY is not set
+ # CONFIG_IP5XXX_POWER is not set
+ # CONFIG_TEST_POWER is not set
+ # CONFIG_CHARGER_ADP5061 is not set
+@@ -1735,6 +1876,8 @@ CONFIG_POWER_SUPPLY=y
+ # CONFIG_BATTERY_SBS is not set
+ # CONFIG_CHARGER_SBS is not set
+ # CONFIG_BATTERY_BQ27XXX is not set
++# CONFIG_AXP20X_POWER is not set
++# CONFIG_BATTERY_MAX17040 is not set
+ # CONFIG_BATTERY_MAX17042 is not set
+ # CONFIG_CHARGER_MAX8903 is not set
+ # CONFIG_CHARGER_LP8727 is not set
+@@ -2278,6 +2421,7 @@ CONFIG_SND_SOC_I2C_AND_SPI=y
+ # CONFIG_SND_SOC_AK5386 is not set
+ # CONFIG_SND_SOC_AK5558 is not set
+ # CONFIG_SND_SOC_ALC5623 is not set
++# CONFIG_SND_SOC_AUDIO_IIO_AUX is not set
+ # CONFIG_SND_SOC_AW8738 is not set
+ # CONFIG_SND_SOC_AW88395 is not set
+ # CONFIG_SND_SOC_AW88261 is not set
+@@ -3139,6 +3283,7 @@ CONFIG_EXTCON=y
+ #
+ # Extcon Device Drivers
+ #
++# CONFIG_EXTCON_ADC_JACK is not set
+ # CONFIG_EXTCON_FSA9480 is not set
+ # CONFIG_EXTCON_GPIO is not set
+ # CONFIG_EXTCON_MAX3355 is not set
+@@ -3147,7 +3292,398 @@ CONFIG_EXTCON=y
+ # CONFIG_EXTCON_SM5502 is not set
+ # CONFIG_EXTCON_USB_GPIO is not set
+ # CONFIG_MEMORY is not set
+-# CONFIG_IIO is not set
++CONFIG_IIO=m
++# CONFIG_IIO_BUFFER is not set
++# CONFIG_IIO_CONFIGFS is not set
++# CONFIG_IIO_TRIGGER is not set
++# CONFIG_IIO_SW_DEVICE is not set
++# CONFIG_IIO_SW_TRIGGER is not set
++# CONFIG_IIO_TRIGGERED_EVENT is not set
++
++#
++# Accelerometers
++#
++# CONFIG_ADXL313_I2C is not set
++# CONFIG_ADXL345_I2C is not set
++# CONFIG_ADXL355_I2C is not set
++# CONFIG_ADXL367_I2C is not set
++# CONFIG_ADXL372_I2C is not set
++# CONFIG_BMA180 is not set
++# CONFIG_BMA400 is not set
++# CONFIG_BMC150_ACCEL is not set
++# CONFIG_DA280 is not set
++# CONFIG_DA311 is not set
++# CONFIG_DMARD06 is not set
++# CONFIG_DMARD09 is not set
++# CONFIG_DMARD10 is not set
++# CONFIG_FXLS8962AF_I2C is not set
++# CONFIG_IIO_ST_ACCEL_3AXIS is not set
++# CONFIG_IIO_KX022A_I2C is not set
++# CONFIG_KXSD9 is not set
++# CONFIG_KXCJK1013 is not set
++# CONFIG_MC3230 is not set
++# CONFIG_MMA7455_I2C is not set
++# CONFIG_MMA7660 is not set
++# CONFIG_MMA8452 is not set
++# CONFIG_MMA9551 is not set
++# CONFIG_MMA9553 is not set
++# CONFIG_MSA311 is not set
++# CONFIG_MXC4005 is not set
++# CONFIG_MXC6255 is not set
++# CONFIG_STK8312 is not set
++# CONFIG_STK8BA50 is not set
++# end of Accelerometers
++
++#
++# Analog to digital converters
++#
++# CONFIG_AD7091R5 is not set
++# CONFIG_AD7291 is not set
++# CONFIG_AD7606_IFACE_PARALLEL is not set
++# CONFIG_AD799X is not set
++# CONFIG_ADI_AXI_ADC is not set
++# CONFIG_AXP20X_ADC is not set
++# CONFIG_AXP288_ADC is not set
++# CONFIG_CC10001_ADC is not set
++# CONFIG_ENVELOPE_DETECTOR is not set
++# CONFIG_HX711 is not set
++# CONFIG_INA2XX_ADC is not set
++# CONFIG_LTC2309 is not set
++# CONFIG_LTC2471 is not set
++# CONFIG_LTC2485 is not set
++# CONFIG_LTC2497 is not set
++# CONFIG_MAX1363 is not set
++# CONFIG_MAX9611 is not set
++# CONFIG_MCP3422 is not set
++# CONFIG_NAU7802 is not set
++# CONFIG_RICHTEK_RTQ6056 is not set
++# CONFIG_SD_ADC_MODULATOR is not set
++# CONFIG_SUN20I_GPADC is not set
++# CONFIG_TI_ADC081C is not set
++# CONFIG_TI_ADS1015 is not set
++# CONFIG_TI_ADS7924 is not set
++# CONFIG_TI_ADS1100 is not set
++# CONFIG_VF610_ADC is not set
++# CONFIG_XILINX_XADC is not set
++# end of Analog to digital converters
++
++#
++# Analog to digital and digital to analog converters
++#
++# end of Analog to digital and digital to analog converters
++
++#
++# Analog Front Ends
++#
++# CONFIG_IIO_RESCALE is not set
++# end of Analog Front Ends
++
++#
++# Amplifiers
++#
++# CONFIG_HMC425 is not set
++# end of Amplifiers
++
++#
++# Capacitance to digital converters
++#
++# CONFIG_AD7150 is not set
++# CONFIG_AD7746 is not set
++# end of Capacitance to digital converters
++
++#
++# Chemical Sensors
++#
++# CONFIG_ATLAS_PH_SENSOR is not set
++# CONFIG_ATLAS_EZO_SENSOR is not set
++# CONFIG_BME680 is not set
++# CONFIG_CCS811 is not set
++# CONFIG_IAQCORE is not set
++# CONFIG_SCD30_CORE is not set
++# CONFIG_SCD4X is not set
++# CONFIG_SENSIRION_SGP30 is not set
++# CONFIG_SENSIRION_SGP40 is not set
++# CONFIG_SPS30_I2C is not set
++# CONFIG_SENSEAIR_SUNRISE_CO2 is not set
++# CONFIG_VZ89X is not set
++# end of Chemical Sensors
++
++#
++# Hid Sensor IIO Common
++#
++# end of Hid Sensor IIO Common
++
++#
++# IIO SCMI Sensors
++#
++# end of IIO SCMI Sensors
++
++#
++# SSP Sensor Common
++#
++# end of SSP Sensor Common
++
++#
++# Digital to analog converters
++#
++# CONFIG_AD5064 is not set
++# CONFIG_AD5380 is not set
++# CONFIG_AD5446 is not set
++# CONFIG_AD5593R is not set
++# CONFIG_AD5696_I2C is not set
++# CONFIG_DPOT_DAC is not set
++# CONFIG_DS4424 is not set
++# CONFIG_M62332 is not set
++# CONFIG_MAX517 is not set
++# CONFIG_MAX5821 is not set
++# CONFIG_MCP4725 is not set
++# CONFIG_MCP4728 is not set
++# CONFIG_TI_DAC5571 is not set
++# CONFIG_VF610_DAC is not set
++# end of Digital to analog converters
++
++#
++# IIO dummy driver
++#
++# end of IIO dummy driver
++
++#
++# Filters
++#
++# end of Filters
++
++#
++# Frequency Synthesizers DDS/PLL
++#
++
++#
++# Clock Generator/Distribution
++#
++# end of Clock Generator/Distribution
++
++#
++# Phase-Locked Loop (PLL) frequency synthesizers
++#
++# end of Phase-Locked Loop (PLL) frequency synthesizers
++# end of Frequency Synthesizers DDS/PLL
++
++#
++# Digital gyroscope sensors
++#
++# CONFIG_BMG160 is not set
++# CONFIG_FXAS21002C is not set
++# CONFIG_MPU3050_I2C is not set
++# CONFIG_IIO_ST_GYRO_3AXIS is not set
++# CONFIG_ITG3200 is not set
++# end of Digital gyroscope sensors
++
++#
++# Health Sensors
++#
++
++#
++# Heart Rate Monitors
++#
++# CONFIG_AFE4404 is not set
++# CONFIG_MAX30100 is not set
++# CONFIG_MAX30102 is not set
++# end of Heart Rate Monitors
++# end of Health Sensors
++
++#
++# Humidity sensors
++#
++# CONFIG_AM2315 is not set
++# CONFIG_DHT11 is not set
++# CONFIG_HDC100X is not set
++# CONFIG_HDC2010 is not set
++# CONFIG_HTS221 is not set
++# CONFIG_HTU21 is not set
++# CONFIG_SI7005 is not set
++# CONFIG_SI7020 is not set
++# end of Humidity sensors
++
++#
++# Inertial measurement units
++#
++# CONFIG_BMI160_I2C is not set
++# CONFIG_BOSCH_BNO055_I2C is not set
++# CONFIG_FXOS8700_I2C is not set
++# CONFIG_KMX61 is not set
++# CONFIG_INV_ICM42600_I2C is not set
++# CONFIG_INV_MPU6050_I2C is not set
++# CONFIG_IIO_ST_LSM6DSX is not set
++# CONFIG_IIO_ST_LSM9DS0 is not set
++# end of Inertial measurement units
++
++#
++# Light sensors
++#
++# CONFIG_ADJD_S311 is not set
++# CONFIG_ADUX1020 is not set
++# CONFIG_AL3010 is not set
++# CONFIG_AL3320A is not set
++# CONFIG_APDS9300 is not set
++# CONFIG_APDS9960 is not set
++# CONFIG_AS73211 is not set
++# CONFIG_BH1750 is not set
++# CONFIG_BH1780 is not set
++# CONFIG_CM32181 is not set
++# CONFIG_CM3232 is not set
++# CONFIG_CM3323 is not set
++# CONFIG_CM3605 is not set
++# CONFIG_CM36651 is not set
++# CONFIG_GP2AP002 is not set
++# CONFIG_GP2AP020A00F is not set
++# CONFIG_SENSORS_ISL29018 is not set
++# CONFIG_SENSORS_ISL29028 is not set
++# CONFIG_ISL29125 is not set
++# CONFIG_JSA1212 is not set
++# CONFIG_ROHM_BU27008 is not set
++# CONFIG_ROHM_BU27034 is not set
++# CONFIG_RPR0521 is not set
++# CONFIG_LTR501 is not set
++# CONFIG_LTRF216A is not set
++# CONFIG_LV0104CS is not set
++# CONFIG_MAX44000 is not set
++# CONFIG_MAX44009 is not set
++# CONFIG_NOA1305 is not set
++# CONFIG_OPT3001 is not set
++# CONFIG_OPT4001 is not set
++# CONFIG_PA12203001 is not set
++# CONFIG_SI1133 is not set
++# CONFIG_SI1145 is not set
++# CONFIG_STK3310 is not set
++# CONFIG_ST_UVIS25 is not set
++# CONFIG_TCS3414 is not set
++# CONFIG_TCS3472 is not set
++# CONFIG_SENSORS_TSL2563 is not set
++# CONFIG_TSL2583 is not set
++# CONFIG_TSL2591 is not set
++# CONFIG_TSL2772 is not set
++# CONFIG_TSL4531 is not set
++# CONFIG_US5182D is not set
++# CONFIG_VCNL4000 is not set
++# CONFIG_VCNL4035 is not set
++# CONFIG_VEML6030 is not set
++# CONFIG_VEML6070 is not set
++# CONFIG_VL6180 is not set
++# CONFIG_ZOPT2201 is not set
++# end of Light sensors
++
++#
++# Magnetometer sensors
++#
++# CONFIG_AK8974 is not set
++# CONFIG_AK8975 is not set
++# CONFIG_AK09911 is not set
++# CONFIG_BMC150_MAGN_I2C is not set
++# CONFIG_MAG3110 is not set
++# CONFIG_MMC35240 is not set
++# CONFIG_IIO_ST_MAGN_3AXIS is not set
++# CONFIG_SENSORS_HMC5843_I2C is not set
++# CONFIG_SENSORS_RM3100_I2C is not set
++# CONFIG_TI_TMAG5273 is not set
++# CONFIG_YAMAHA_YAS530 is not set
++# end of Magnetometer sensors
++
++#
++# Multiplexers
++#
++# CONFIG_IIO_MUX is not set
++# end of Multiplexers
++
++#
++# Inclinometer sensors
++#
++# end of Inclinometer sensors
++
++#
++# Linear and angular position sensors
++#
++# end of Linear and angular position sensors
++
++#
++# Digital potentiometers
++#
++# CONFIG_AD5110 is not set
++# CONFIG_AD5272 is not set
++# CONFIG_DS1803 is not set
++# CONFIG_MAX5432 is not set
++# CONFIG_MCP4018 is not set
++# CONFIG_MCP4531 is not set
++# CONFIG_TPL0102 is not set
++# end of Digital potentiometers
++
++#
++# Digital potentiostats
++#
++# CONFIG_LMP91000 is not set
++# end of Digital potentiostats
++
++#
++# Pressure sensors
++#
++# CONFIG_ABP060MG is not set
++# CONFIG_ROHM_BM1390 is not set
++# CONFIG_BMP280 is not set
++# CONFIG_DLHL60D is not set
++# CONFIG_DPS310 is not set
++# CONFIG_HP03 is not set
++# CONFIG_ICP10100 is not set
++# CONFIG_MPL115_I2C is not set
++# CONFIG_MPL3115 is not set
++# CONFIG_MPRLS0025PA is not set
++# CONFIG_MS5611 is not set
++# CONFIG_MS5637 is not set
++# CONFIG_IIO_ST_PRESS is not set
++# CONFIG_T5403 is not set
++# CONFIG_HP206C is not set
++# CONFIG_ZPA2326 is not set
++# end of Pressure sensors
++
++#
++# Lightning sensors
++#
++# end of Lightning sensors
++
++#
++# Proximity and distance sensors
++#
++# CONFIG_IRSD200 is not set
++# CONFIG_ISL29501 is not set
++# CONFIG_LIDAR_LITE_V2 is not set
++# CONFIG_MB1232 is not set
++# CONFIG_PING is not set
++# CONFIG_RFD77402 is not set
++# CONFIG_SRF04 is not set
++# CONFIG_SX9310 is not set
++# CONFIG_SX9324 is not set
++# CONFIG_SX9360 is not set
++# CONFIG_SX9500 is not set
++# CONFIG_SRF08 is not set
++# CONFIG_VCNL3020 is not set
++# CONFIG_VL53L0X_I2C is not set
++# end of Proximity and distance sensors
++
++#
++# Resolver to digital converters
++#
++# end of Resolver to digital converters
++
++#
++# Temperature sensors
++#
++# CONFIG_MLX90614 is not set
++# CONFIG_MLX90632 is not set
++# CONFIG_TMP006 is not set
++# CONFIG_TMP007 is not set
++# CONFIG_TMP117 is not set
++# CONFIG_TSYS01 is not set
++# CONFIG_TSYS02D is not set
++# CONFIG_MAX30208 is not set
++# end of Temperature sensors
++
+ # CONFIG_PWM is not set
+ 
+ #
+@@ -3197,6 +3733,7 @@ CONFIG_PHY_SUN4I_USB=y
+ # CONFIG_PHY_PXA_28NM_HSIC is not set
+ # CONFIG_PHY_PXA_28NM_USB2 is not set
+ # CONFIG_PHY_LAN966X_SERDES is not set
++# CONFIG_PHY_CPCAP_USB is not set
+ # CONFIG_PHY_MAPPHONE_MDM6600 is not set
+ # CONFIG_PHY_OCELOT_SERDES is not set
+ # end of PHY Subsystem
+-- 
+2.43.0
+

--- a/linux/k8s-filesystem-changes.patch
+++ b/linux/k8s-filesystem-changes.patch
@@ -1,0 +1,820 @@
+From d0e992240b5fb50b94d87de106ecd0ae1e623069 Mon Sep 17 00:00:00 2001
+From: elasticdotventures <brianh@elastic.ventures>
+Date: Mon, 22 Jan 2024 07:22:17 +0000
+Subject: [PATCH] filesystem changes
+
+---
+ arch/arm64/configs/longanpi_3h_defconfig | 604 ++++++++++++++++++++++-
+ 1 file changed, 592 insertions(+), 12 deletions(-)
+
+diff --git a/arch/arm64/configs/longanpi_3h_defconfig b/arch/arm64/configs/longanpi_3h_defconfig
+index d87fa768eb75..f111b3efd7b9 100644
+--- a/arch/arm64/configs/longanpi_3h_defconfig
++++ b/arch/arm64/configs/longanpi_3h_defconfig
+@@ -555,7 +555,8 @@ CONFIG_ISA_DMA_API=y
+ # end of Binary Emulations
+ 
+ CONFIG_HAVE_KVM=y
+-# CONFIG_VIRTUALIZATION is not set
++CONFIG_VIRTUALIZATION=y
++# CONFIG_KVM is not set
+ CONFIG_AS_AVX512=y
+ CONFIG_AS_SHA1_NI=y
+ CONFIG_AS_SHA256_NI=y
+@@ -758,6 +759,7 @@ CONFIG_EFI_PARTITION=y
+ # CONFIG_CMDLINE_PARTITION is not set
+ # end of Partition Types
+ 
++CONFIG_BLK_MQ_VIRTIO=y
+ CONFIG_BLK_PM=y
+ 
+ #
+@@ -882,6 +884,9 @@ CONFIG_LOCK_MM_AND_FIND_VMA=y
+ # end of Memory Management options
+ 
+ CONFIG_NET=y
++CONFIG_NET_INGRESS=y
++CONFIG_NET_EGRESS=y
++CONFIG_SKB_EXTENSIONS=y
+ 
+ #
+ # Networking options
+@@ -895,19 +900,23 @@ CONFIG_AF_UNIX_OOB=y
+ # CONFIG_TLS is not set
+ # CONFIG_XFRM_USER is not set
+ # CONFIG_NET_KEY is not set
++CONFIG_NET_HANDSHAKE=y
+ CONFIG_INET=y
+ # CONFIG_IP_MULTICAST is not set
+ # CONFIG_IP_ADVANCED_ROUTER is not set
+ # CONFIG_IP_PNP is not set
+ # CONFIG_NET_IPIP is not set
+ # CONFIG_NET_IPGRE_DEMUX is not set
++CONFIG_NET_IP_TUNNEL=m
+ # CONFIG_SYN_COOKIES is not set
+ # CONFIG_NET_IPVTI is not set
+ # CONFIG_NET_FOU is not set
++# CONFIG_NET_FOU_IP_TUNNELS is not set
+ # CONFIG_INET_AH is not set
+ # CONFIG_INET_ESP is not set
+ # CONFIG_INET_IPCOMP is not set
+ CONFIG_INET_TABLE_PERTURB_ORDER=16
++CONFIG_INET_TUNNEL=m
+ # CONFIG_INET_DIAG is not set
+ CONFIG_TCP_CONG_ADVANCED=y
+ CONFIG_TCP_CONG_BIC=m
+@@ -929,13 +938,138 @@ CONFIG_TCP_CONG_HTCP=m
+ CONFIG_DEFAULT_CUBIC=y
+ # CONFIG_DEFAULT_RENO is not set
+ CONFIG_DEFAULT_TCP_CONG="cubic"
+-# CONFIG_TCP_AO is not set
+ # CONFIG_TCP_MD5SIG is not set
+-# CONFIG_IPV6 is not set
++CONFIG_IPV6=m
++# CONFIG_IPV6_ROUTER_PREF is not set
++# CONFIG_IPV6_OPTIMISTIC_DAD is not set
++# CONFIG_INET6_AH is not set
++# CONFIG_INET6_ESP is not set
++# CONFIG_INET6_IPCOMP is not set
++# CONFIG_IPV6_MIP6 is not set
++# CONFIG_IPV6_ILA is not set
++# CONFIG_IPV6_VTI is not set
++CONFIG_IPV6_SIT=m
++# CONFIG_IPV6_SIT_6RD is not set
++CONFIG_IPV6_NDISC_NODETYPE=y
++# CONFIG_IPV6_TUNNEL is not set
++# CONFIG_IPV6_MULTIPLE_TABLES is not set
++# CONFIG_IPV6_MROUTE is not set
++# CONFIG_IPV6_SEG6_LWTUNNEL is not set
++# CONFIG_IPV6_SEG6_HMAC is not set
++# CONFIG_IPV6_RPL_LWTUNNEL is not set
++# CONFIG_IPV6_IOAM6_LWTUNNEL is not set
+ # CONFIG_MPTCP is not set
+ # CONFIG_NETWORK_SECMARK is not set
+ # CONFIG_NETWORK_PHY_TIMESTAMPING is not set
+-# CONFIG_NETFILTER is not set
++CONFIG_NETFILTER=y
++CONFIG_NETFILTER_ADVANCED=y
++CONFIG_BRIDGE_NETFILTER=m
++
++#
++# Core Netfilter Configuration
++#
++CONFIG_NETFILTER_INGRESS=y
++CONFIG_NETFILTER_EGRESS=y
++CONFIG_NETFILTER_NETLINK=m
++CONFIG_NETFILTER_FAMILY_BRIDGE=y
++# CONFIG_NETFILTER_NETLINK_ACCT is not set
++# CONFIG_NETFILTER_NETLINK_QUEUE is not set
++# CONFIG_NETFILTER_NETLINK_LOG is not set
++# CONFIG_NETFILTER_NETLINK_OSF is not set
++# CONFIG_NF_CONNTRACK is not set
++# CONFIG_NF_LOG_SYSLOG is not set
++# CONFIG_NF_TABLES is not set
++# CONFIG_NETFILTER_XTABLES is not set
++# end of Core Netfilter Configuration
++
++CONFIG_IP_SET=m
++CONFIG_IP_SET_MAX=256
++# CONFIG_IP_SET_BITMAP_IP is not set
++# CONFIG_IP_SET_BITMAP_IPMAC is not set
++# CONFIG_IP_SET_BITMAP_PORT is not set
++# CONFIG_IP_SET_HASH_IP is not set
++# CONFIG_IP_SET_HASH_IPMARK is not set
++# CONFIG_IP_SET_HASH_IPPORT is not set
++# CONFIG_IP_SET_HASH_IPPORTIP is not set
++# CONFIG_IP_SET_HASH_IPPORTNET is not set
++# CONFIG_IP_SET_HASH_IPMAC is not set
++# CONFIG_IP_SET_HASH_MAC is not set
++# CONFIG_IP_SET_HASH_NETPORTNET is not set
++# CONFIG_IP_SET_HASH_NET is not set
++# CONFIG_IP_SET_HASH_NETNET is not set
++# CONFIG_IP_SET_HASH_NETPORT is not set
++# CONFIG_IP_SET_HASH_NETIFACE is not set
++# CONFIG_IP_SET_LIST_SET is not set
++CONFIG_IP_VS=m
++# CONFIG_IP_VS_IPV6 is not set
++# CONFIG_IP_VS_DEBUG is not set
++CONFIG_IP_VS_TAB_BITS=12
++
++#
++# IPVS transport protocol load balancing support
++#
++# CONFIG_IP_VS_PROTO_TCP is not set
++# CONFIG_IP_VS_PROTO_UDP is not set
++# CONFIG_IP_VS_PROTO_ESP is not set
++# CONFIG_IP_VS_PROTO_AH is not set
++# CONFIG_IP_VS_PROTO_SCTP is not set
++
++#
++# IPVS scheduler
++#
++# CONFIG_IP_VS_RR is not set
++# CONFIG_IP_VS_WRR is not set
++# CONFIG_IP_VS_LC is not set
++# CONFIG_IP_VS_WLC is not set
++# CONFIG_IP_VS_FO is not set
++# CONFIG_IP_VS_OVF is not set
++# CONFIG_IP_VS_LBLC is not set
++# CONFIG_IP_VS_LBLCR is not set
++# CONFIG_IP_VS_DH is not set
++# CONFIG_IP_VS_SH is not set
++# CONFIG_IP_VS_MH is not set
++# CONFIG_IP_VS_SED is not set
++# CONFIG_IP_VS_NQ is not set
++# CONFIG_IP_VS_TWOS is not set
++
++#
++# IPVS SH scheduler
++#
++CONFIG_IP_VS_SH_TAB_BITS=8
++
++#
++# IPVS MH scheduler
++#
++CONFIG_IP_VS_MH_TAB_INDEX=12
++
++#
++# IPVS application helper
++#
++
++#
++# IP: Netfilter Configuration
++#
++# CONFIG_NF_SOCKET_IPV4 is not set
++# CONFIG_NF_TPROXY_IPV4 is not set
++# CONFIG_NF_DUP_IPV4 is not set
++# CONFIG_NF_LOG_ARP is not set
++# CONFIG_NF_LOG_IPV4 is not set
++# CONFIG_NF_REJECT_IPV4 is not set
++# CONFIG_IP_NF_IPTABLES is not set
++# CONFIG_IP_NF_ARPTABLES is not set
++# end of IP: Netfilter Configuration
++
++#
++# IPv6: Netfilter Configuration
++#
++CONFIG_NF_SOCKET_IPV6=m
++# CONFIG_NF_TPROXY_IPV6 is not set
++# CONFIG_NF_DUP_IPV6 is not set
++# CONFIG_NF_REJECT_IPV6 is not set
++# CONFIG_NF_LOG_IPV6 is not set
++# CONFIG_IP6_NF_IPTABLES is not set
++# end of IPv6: Netfilter Configuration
++
+ # CONFIG_BPFILTER is not set
+ # CONFIG_IP_DCCP is not set
+ # CONFIG_IP_SCTP is not set
+@@ -943,14 +1077,20 @@ CONFIG_DEFAULT_TCP_CONG="cubic"
+ # CONFIG_TIPC is not set
+ # CONFIG_ATM is not set
+ # CONFIG_L2TP is not set
+-# CONFIG_BRIDGE is not set
++CONFIG_STP=m
++CONFIG_BRIDGE=m
++CONFIG_BRIDGE_IGMP_SNOOPING=y
++# CONFIG_BRIDGE_MRP is not set
++# CONFIG_BRIDGE_CFM is not set
+ # CONFIG_NET_DSA is not set
+ # CONFIG_VLAN_8021Q is not set
++CONFIG_LLC=m
+ # CONFIG_LLC2 is not set
+ # CONFIG_ATALK is not set
+ # CONFIG_X25 is not set
+ # CONFIG_LAPB is not set
+ # CONFIG_PHONET is not set
++# CONFIG_6LOWPAN is not set
+ # CONFIG_IEEE802154 is not set
+ # CONFIG_NET_SCHED is not set
+ # CONFIG_DCB is not set
+@@ -1028,6 +1168,7 @@ CONFIG_BT_HCIVHCI=y
+ # CONFIG_BT_MRVL is not set
+ # CONFIG_BT_ATH3K is not set
+ # CONFIG_BT_MTKSDIO is not set
++# CONFIG_BT_VIRTIO is not set
+ # end of Bluetooth device drivers
+ 
+ # CONFIG_AF_RXRPC is not set
+@@ -1060,11 +1201,15 @@ CONFIG_RFKILL=y
+ CONFIG_RFKILL_GPIO=y
+ # CONFIG_NET_9P is not set
+ # CONFIG_CAIF is not set
+-# CONFIG_CEPH_LIB is not set
++CONFIG_CEPH_LIB=m
++# CONFIG_CEPH_LIB_PRETTYDEBUG is not set
++# CONFIG_CEPH_LIB_USE_DNS_RESOLVER is not set
+ # CONFIG_NFC is not set
+ # CONFIG_PSAMPLE is not set
+ # CONFIG_NET_IFE is not set
+ # CONFIG_LWTUNNEL is not set
++CONFIG_DST_CACHE=y
++CONFIG_GRO_CELLS=y
+ CONFIG_NET_SELFTESTS=y
+ CONFIG_PAGE_POOL=y
+ # CONFIG_PAGE_POOL_STATS is not set
+@@ -1291,6 +1436,7 @@ CONFIG_NET_CORE=y
+ # CONFIG_TUN is not set
+ # CONFIG_TUN_VNET_CROSS_LE is not set
+ # CONFIG_VETH is not set
++# CONFIG_VIRTIO_NET is not set
+ # CONFIG_NLMON is not set
+ CONFIG_ETHERNET=y
+ # CONFIG_NET_VENDOR_ALACRITECH is not set
+@@ -1771,6 +1917,7 @@ CONFIG_GPIO_SYSCON=y
+ # CONFIG_GPIO_AGGREGATOR is not set
+ # CONFIG_GPIO_LATCH is not set
+ # CONFIG_GPIO_MOCKUP is not set
++# CONFIG_GPIO_VIRTIO is not set
+ # CONFIG_GPIO_SIM is not set
+ # end of Virtual GPIO drivers
+ 
+@@ -1787,6 +1934,7 @@ CONFIG_POWER_RESET_SYSCON=y
+ # CONFIG_NVMEM_REBOOT_MODE is not set
+ CONFIG_POWER_SUPPLY=y
+ # CONFIG_POWER_SUPPLY_DEBUG is not set
++# CONFIG_GENERIC_ADC_BATTERY is not set
+ # CONFIG_IP5XXX_POWER is not set
+ # CONFIG_TEST_POWER is not set
+ # CONFIG_CHARGER_ADP5061 is not set
+@@ -1798,6 +1946,8 @@ CONFIG_POWER_SUPPLY=y
+ # CONFIG_BATTERY_SBS is not set
+ # CONFIG_CHARGER_SBS is not set
+ # CONFIG_BATTERY_BQ27XXX is not set
++# CONFIG_AXP20X_POWER is not set
++# CONFIG_BATTERY_MAX17040 is not set
+ # CONFIG_BATTERY_MAX17042 is not set
+ # CONFIG_CHARGER_MAX8903 is not set
+ # CONFIG_CHARGER_LP8727 is not set
+@@ -1861,6 +2011,7 @@ CONFIG_X86_PKG_TEMP_THERMAL=m
+ # CONFIG_INTEL_HFI_THERMAL is not set
+ # end of Intel thermal drivers
+ 
++# CONFIG_GENERIC_ADC_THERMAL is not set
+ CONFIG_WATCHDOG=y
+ CONFIG_WATCHDOG_CORE=y
+ # CONFIG_WATCHDOG_NOWAYOUT is not set
+@@ -2371,6 +2522,7 @@ CONFIG_SND_SOC_I2C_AND_SPI=y
+ # CONFIG_SND_SOC_AK5386 is not set
+ # CONFIG_SND_SOC_AK5558 is not set
+ # CONFIG_SND_SOC_ALC5623 is not set
++# CONFIG_SND_SOC_AUDIO_IIO_AUX is not set
+ # CONFIG_SND_SOC_AW8738 is not set
+ # CONFIG_SND_SOC_AW88395 is not set
+ # CONFIG_SND_SOC_AW88261 is not set
+@@ -2525,6 +2677,7 @@ CONFIG_SND_SOC_BT_SCO=y
+ # CONFIG_SND_AUDIO_GRAPH_CARD2 is not set
+ # CONFIG_SND_TEST_COMPONENT is not set
+ CONFIG_SND_X86=y
++# CONFIG_SND_VIRTIO is not set
+ CONFIG_HID_SUPPORT=y
+ CONFIG_HID=y
+ # CONFIG_HID_BATTERY_STRENGTH is not set
+@@ -3057,6 +3210,8 @@ CONFIG_SYNC_FILE=y
+ # CONFIG_UIO is not set
+ # CONFIG_VFIO is not set
+ # CONFIG_VIRT_DRIVERS is not set
++CONFIG_VIRTIO_ANCHOR=y
++CONFIG_VIRTIO=m
+ # CONFIG_VIRTIO_MENU is not set
+ # CONFIG_VDPA is not set
+ # CONFIG_VHOST_MENU is not set
+@@ -3242,6 +3397,7 @@ CONFIG_EXTCON=y
+ #
+ # Extcon Device Drivers
+ #
++# CONFIG_EXTCON_ADC_JACK is not set
+ # CONFIG_EXTCON_FSA9480 is not set
+ # CONFIG_EXTCON_GPIO is not set
+ # CONFIG_EXTCON_INTEL_INT3496 is not set
+@@ -3251,7 +3407,398 @@ CONFIG_EXTCON=y
+ # CONFIG_EXTCON_SM5502 is not set
+ # CONFIG_EXTCON_USB_GPIO is not set
+ # CONFIG_MEMORY is not set
+-# CONFIG_IIO is not set
++CONFIG_IIO=m
++# CONFIG_IIO_BUFFER is not set
++# CONFIG_IIO_CONFIGFS is not set
++# CONFIG_IIO_TRIGGER is not set
++# CONFIG_IIO_SW_DEVICE is not set
++# CONFIG_IIO_SW_TRIGGER is not set
++# CONFIG_IIO_TRIGGERED_EVENT is not set
++
++#
++# Accelerometers
++#
++# CONFIG_ADXL313_I2C is not set
++# CONFIG_ADXL345_I2C is not set
++# CONFIG_ADXL355_I2C is not set
++# CONFIG_ADXL367_I2C is not set
++# CONFIG_ADXL372_I2C is not set
++# CONFIG_BMA180 is not set
++# CONFIG_BMA400 is not set
++# CONFIG_BMC150_ACCEL is not set
++# CONFIG_DA280 is not set
++# CONFIG_DA311 is not set
++# CONFIG_DMARD06 is not set
++# CONFIG_DMARD09 is not set
++# CONFIG_DMARD10 is not set
++# CONFIG_FXLS8962AF_I2C is not set
++# CONFIG_IIO_ST_ACCEL_3AXIS is not set
++# CONFIG_IIO_KX022A_I2C is not set
++# CONFIG_KXSD9 is not set
++# CONFIG_KXCJK1013 is not set
++# CONFIG_MC3230 is not set
++# CONFIG_MMA7455_I2C is not set
++# CONFIG_MMA7660 is not set
++# CONFIG_MMA8452 is not set
++# CONFIG_MMA9551 is not set
++# CONFIG_MMA9553 is not set
++# CONFIG_MSA311 is not set
++# CONFIG_MXC4005 is not set
++# CONFIG_MXC6255 is not set
++# CONFIG_STK8312 is not set
++# CONFIG_STK8BA50 is not set
++# end of Accelerometers
++
++#
++# Analog to digital converters
++#
++# CONFIG_AD7091R5 is not set
++# CONFIG_AD7291 is not set
++# CONFIG_AD7606_IFACE_PARALLEL is not set
++# CONFIG_AD799X is not set
++# CONFIG_ADI_AXI_ADC is not set
++# CONFIG_AXP20X_ADC is not set
++# CONFIG_AXP288_ADC is not set
++# CONFIG_CC10001_ADC is not set
++# CONFIG_ENVELOPE_DETECTOR is not set
++# CONFIG_HX711 is not set
++# CONFIG_INA2XX_ADC is not set
++# CONFIG_LTC2309 is not set
++# CONFIG_LTC2471 is not set
++# CONFIG_LTC2485 is not set
++# CONFIG_LTC2497 is not set
++# CONFIG_MAX1363 is not set
++# CONFIG_MAX9611 is not set
++# CONFIG_MCP3422 is not set
++# CONFIG_NAU7802 is not set
++# CONFIG_RICHTEK_RTQ6056 is not set
++# CONFIG_SD_ADC_MODULATOR is not set
++# CONFIG_TI_ADC081C is not set
++# CONFIG_TI_ADS1015 is not set
++# CONFIG_TI_ADS7924 is not set
++# CONFIG_TI_ADS1100 is not set
++# CONFIG_VF610_ADC is not set
++# CONFIG_XILINX_XADC is not set
++# end of Analog to digital converters
++
++#
++# Analog to digital and digital to analog converters
++#
++# end of Analog to digital and digital to analog converters
++
++#
++# Analog Front Ends
++#
++# CONFIG_IIO_RESCALE is not set
++# end of Analog Front Ends
++
++#
++# Amplifiers
++#
++# CONFIG_HMC425 is not set
++# end of Amplifiers
++
++#
++# Capacitance to digital converters
++#
++# CONFIG_AD7150 is not set
++# CONFIG_AD7746 is not set
++# end of Capacitance to digital converters
++
++#
++# Chemical Sensors
++#
++# CONFIG_ATLAS_PH_SENSOR is not set
++# CONFIG_ATLAS_EZO_SENSOR is not set
++# CONFIG_BME680 is not set
++# CONFIG_CCS811 is not set
++# CONFIG_IAQCORE is not set
++# CONFIG_SCD30_CORE is not set
++# CONFIG_SCD4X is not set
++# CONFIG_SENSIRION_SGP30 is not set
++# CONFIG_SENSIRION_SGP40 is not set
++# CONFIG_SPS30_I2C is not set
++# CONFIG_SENSEAIR_SUNRISE_CO2 is not set
++# CONFIG_VZ89X is not set
++# end of Chemical Sensors
++
++#
++# Hid Sensor IIO Common
++#
++# end of Hid Sensor IIO Common
++
++#
++# IIO SCMI Sensors
++#
++# end of IIO SCMI Sensors
++
++#
++# SSP Sensor Common
++#
++# end of SSP Sensor Common
++
++#
++# Digital to analog converters
++#
++# CONFIG_AD5064 is not set
++# CONFIG_AD5380 is not set
++# CONFIG_AD5446 is not set
++# CONFIG_AD5593R is not set
++# CONFIG_AD5696_I2C is not set
++# CONFIG_DPOT_DAC is not set
++# CONFIG_DS4424 is not set
++# CONFIG_M62332 is not set
++# CONFIG_MAX517 is not set
++# CONFIG_MAX5821 is not set
++# CONFIG_MCP4725 is not set
++# CONFIG_MCP4728 is not set
++# CONFIG_TI_DAC5571 is not set
++# CONFIG_VF610_DAC is not set
++# end of Digital to analog converters
++
++#
++# IIO dummy driver
++#
++# end of IIO dummy driver
++
++#
++# Filters
++#
++# end of Filters
++
++#
++# Frequency Synthesizers DDS/PLL
++#
++
++#
++# Clock Generator/Distribution
++#
++# end of Clock Generator/Distribution
++
++#
++# Phase-Locked Loop (PLL) frequency synthesizers
++#
++# end of Phase-Locked Loop (PLL) frequency synthesizers
++# end of Frequency Synthesizers DDS/PLL
++
++#
++# Digital gyroscope sensors
++#
++# CONFIG_BMG160 is not set
++# CONFIG_FXAS21002C is not set
++# CONFIG_MPU3050_I2C is not set
++# CONFIG_IIO_ST_GYRO_3AXIS is not set
++# CONFIG_ITG3200 is not set
++# end of Digital gyroscope sensors
++
++#
++# Health Sensors
++#
++
++#
++# Heart Rate Monitors
++#
++# CONFIG_AFE4404 is not set
++# CONFIG_MAX30100 is not set
++# CONFIG_MAX30102 is not set
++# end of Heart Rate Monitors
++# end of Health Sensors
++
++#
++# Humidity sensors
++#
++# CONFIG_AM2315 is not set
++# CONFIG_DHT11 is not set
++# CONFIG_HDC100X is not set
++# CONFIG_HDC2010 is not set
++# CONFIG_HTS221 is not set
++# CONFIG_HTU21 is not set
++# CONFIG_SI7005 is not set
++# CONFIG_SI7020 is not set
++# end of Humidity sensors
++
++#
++# Inertial measurement units
++#
++# CONFIG_BMI160_I2C is not set
++# CONFIG_BOSCH_BNO055_I2C is not set
++# CONFIG_FXOS8700_I2C is not set
++# CONFIG_KMX61 is not set
++# CONFIG_INV_ICM42600_I2C is not set
++# CONFIG_INV_MPU6050_I2C is not set
++# CONFIG_IIO_ST_LSM6DSX is not set
++# CONFIG_IIO_ST_LSM9DS0 is not set
++# end of Inertial measurement units
++
++#
++# Light sensors
++#
++# CONFIG_ACPI_ALS is not set
++# CONFIG_ADJD_S311 is not set
++# CONFIG_ADUX1020 is not set
++# CONFIG_AL3010 is not set
++# CONFIG_AL3320A is not set
++# CONFIG_APDS9300 is not set
++# CONFIG_APDS9960 is not set
++# CONFIG_AS73211 is not set
++# CONFIG_BH1750 is not set
++# CONFIG_BH1780 is not set
++# CONFIG_CM32181 is not set
++# CONFIG_CM3232 is not set
++# CONFIG_CM3323 is not set
++# CONFIG_CM3605 is not set
++# CONFIG_CM36651 is not set
++# CONFIG_GP2AP002 is not set
++# CONFIG_GP2AP020A00F is not set
++# CONFIG_SENSORS_ISL29018 is not set
++# CONFIG_SENSORS_ISL29028 is not set
++# CONFIG_ISL29125 is not set
++# CONFIG_JSA1212 is not set
++# CONFIG_ROHM_BU27008 is not set
++# CONFIG_ROHM_BU27034 is not set
++# CONFIG_RPR0521 is not set
++# CONFIG_LTR501 is not set
++# CONFIG_LTRF216A is not set
++# CONFIG_LV0104CS is not set
++# CONFIG_MAX44000 is not set
++# CONFIG_MAX44009 is not set
++# CONFIG_NOA1305 is not set
++# CONFIG_OPT3001 is not set
++# CONFIG_OPT4001 is not set
++# CONFIG_PA12203001 is not set
++# CONFIG_SI1133 is not set
++# CONFIG_SI1145 is not set
++# CONFIG_STK3310 is not set
++# CONFIG_ST_UVIS25 is not set
++# CONFIG_TCS3414 is not set
++# CONFIG_TCS3472 is not set
++# CONFIG_SENSORS_TSL2563 is not set
++# CONFIG_TSL2583 is not set
++# CONFIG_TSL2591 is not set
++# CONFIG_TSL2772 is not set
++# CONFIG_TSL4531 is not set
++# CONFIG_US5182D is not set
++# CONFIG_VCNL4000 is not set
++# CONFIG_VCNL4035 is not set
++# CONFIG_VEML6030 is not set
++# CONFIG_VEML6070 is not set
++# CONFIG_VL6180 is not set
++# CONFIG_ZOPT2201 is not set
++# end of Light sensors
++
++#
++# Magnetometer sensors
++#
++# CONFIG_AK8974 is not set
++# CONFIG_AK8975 is not set
++# CONFIG_AK09911 is not set
++# CONFIG_BMC150_MAGN_I2C is not set
++# CONFIG_MAG3110 is not set
++# CONFIG_MMC35240 is not set
++# CONFIG_IIO_ST_MAGN_3AXIS is not set
++# CONFIG_SENSORS_HMC5843_I2C is not set
++# CONFIG_SENSORS_RM3100_I2C is not set
++# CONFIG_TI_TMAG5273 is not set
++# CONFIG_YAMAHA_YAS530 is not set
++# end of Magnetometer sensors
++
++#
++# Multiplexers
++#
++# CONFIG_IIO_MUX is not set
++# end of Multiplexers
++
++#
++# Inclinometer sensors
++#
++# end of Inclinometer sensors
++
++#
++# Linear and angular position sensors
++#
++# end of Linear and angular position sensors
++
++#
++# Digital potentiometers
++#
++# CONFIG_AD5110 is not set
++# CONFIG_AD5272 is not set
++# CONFIG_DS1803 is not set
++# CONFIG_MAX5432 is not set
++# CONFIG_MCP4018 is not set
++# CONFIG_MCP4531 is not set
++# CONFIG_TPL0102 is not set
++# end of Digital potentiometers
++
++#
++# Digital potentiostats
++#
++# CONFIG_LMP91000 is not set
++# end of Digital potentiostats
++
++#
++# Pressure sensors
++#
++# CONFIG_ABP060MG is not set
++# CONFIG_ROHM_BM1390 is not set
++# CONFIG_BMP280 is not set
++# CONFIG_DLHL60D is not set
++# CONFIG_DPS310 is not set
++# CONFIG_HP03 is not set
++# CONFIG_ICP10100 is not set
++# CONFIG_MPL115_I2C is not set
++# CONFIG_MPL3115 is not set
++# CONFIG_MPRLS0025PA is not set
++# CONFIG_MS5611 is not set
++# CONFIG_MS5637 is not set
++# CONFIG_IIO_ST_PRESS is not set
++# CONFIG_T5403 is not set
++# CONFIG_HP206C is not set
++# CONFIG_ZPA2326 is not set
++# end of Pressure sensors
++
++#
++# Lightning sensors
++#
++# end of Lightning sensors
++
++#
++# Proximity and distance sensors
++#
++# CONFIG_IRSD200 is not set
++# CONFIG_ISL29501 is not set
++# CONFIG_LIDAR_LITE_V2 is not set
++# CONFIG_MB1232 is not set
++# CONFIG_PING is not set
++# CONFIG_RFD77402 is not set
++# CONFIG_SRF04 is not set
++# CONFIG_SX9310 is not set
++# CONFIG_SX9324 is not set
++# CONFIG_SX9360 is not set
++# CONFIG_SX9500 is not set
++# CONFIG_SRF08 is not set
++# CONFIG_VCNL3020 is not set
++# CONFIG_VL53L0X_I2C is not set
++# end of Proximity and distance sensors
++
++#
++# Resolver to digital converters
++#
++# end of Resolver to digital converters
++
++#
++# Temperature sensors
++#
++# CONFIG_MLX90614 is not set
++# CONFIG_MLX90632 is not set
++# CONFIG_TMP006 is not set
++# CONFIG_TMP007 is not set
++# CONFIG_TMP117 is not set
++# CONFIG_TSYS01 is not set
++# CONFIG_TSYS02D is not set
++# CONFIG_MAX30208 is not set
++# end of Temperature sensors
++
+ # CONFIG_PWM is not set
+ 
+ #
+@@ -3290,6 +3837,7 @@ CONFIG_GENERIC_PHY=y
+ # CONFIG_PHY_PXA_28NM_HSIC is not set
+ # CONFIG_PHY_PXA_28NM_USB2 is not set
+ # CONFIG_PHY_LAN966X_SERDES is not set
++# CONFIG_PHY_CPCAP_USB is not set
+ # CONFIG_PHY_MAPPHONE_MDM6600 is not set
+ # CONFIG_PHY_OCELOT_SERDES is not set
+ # CONFIG_PHY_INTEL_LGM_COMBO is not set
+@@ -3371,6 +3919,7 @@ CONFIG_FS_MBCACHE=y
+ # CONFIG_NILFS2_FS is not set
+ # CONFIG_F2FS_FS is not set
+ # CONFIG_BCACHEFS_FS is not set
++CONFIG_FS_POSIX_ACL=y
+ CONFIG_EXPORTFS=y
+ # CONFIG_EXPORTFS_BLOCK_OPS is not set
+ CONFIG_FILE_LOCKING=y
+@@ -3382,12 +3931,22 @@ CONFIG_INOTIFY_USER=y
+ CONFIG_FANOTIFY=y
+ # CONFIG_QUOTA is not set
+ # CONFIG_AUTOFS_FS is not set
+-# CONFIG_FUSE_FS is not set
+-# CONFIG_OVERLAY_FS is not set
++CONFIG_FUSE_FS=m
++# CONFIG_CUSE is not set
++CONFIG_VIRTIO_FS=m
++CONFIG_OVERLAY_FS=m
++CONFIG_OVERLAY_FS_REDIRECT_DIR=y
++CONFIG_OVERLAY_FS_REDIRECT_ALWAYS_FOLLOW=y
++# CONFIG_OVERLAY_FS_INDEX is not set
++# CONFIG_OVERLAY_FS_XINO_AUTO is not set
++# CONFIG_OVERLAY_FS_METACOPY is not set
++# CONFIG_OVERLAY_FS_DEBUG is not set
+ 
+ #
+ # Caches
+ #
++CONFIG_NETFS_SUPPORT=m
++# CONFIG_NETFS_STATS is not set
+ # CONFIG_FSCACHE is not set
+ # end of Caches
+ 
+@@ -3430,7 +3989,28 @@ CONFIG_CONFIGFS_FS=m
+ # end of Pseudo filesystems
+ 
+ # CONFIG_MISC_FILESYSTEMS is not set
+-# CONFIG_NETWORK_FILESYSTEMS is not set
++CONFIG_NETWORK_FILESYSTEMS=y
++CONFIG_NFS_FS=m
++CONFIG_NFS_V2=m
++CONFIG_NFS_V3=m
++# CONFIG_NFS_V3_ACL is not set
++# CONFIG_NFS_V4 is not set
++CONFIG_NFS_DISABLE_UDP_SUPPORT=y
++# CONFIG_NFSD is not set
++CONFIG_GRACE_PERIOD=m
++CONFIG_LOCKD=m
++CONFIG_LOCKD_V4=y
++CONFIG_NFS_COMMON=y
++CONFIG_SUNRPC=m
++CONFIG_SUNRPC_GSS=m
++CONFIG_RPCSEC_GSS_KRB5=m
++# CONFIG_SUNRPC_DEBUG is not set
++CONFIG_CEPH_FS=m
++# CONFIG_CEPH_FS_POSIX_ACL is not set
++# CONFIG_CIFS is not set
++# CONFIG_SMB_SERVER is not set
++# CONFIG_CODA_FS is not set
++# CONFIG_AFS_FS is not set
+ CONFIG_NLS=y
+ CONFIG_NLS_DEFAULT="utf8"
+ CONFIG_NLS_CODEPAGE_437=y
+@@ -3599,7 +4179,7 @@ CONFIG_CRYPTO_AES=y
+ #
+ # CONFIG_CRYPTO_ADIANTUM is not set
+ # CONFIG_CRYPTO_CHACHA20 is not set
+-# CONFIG_CRYPTO_CBC is not set
++CONFIG_CRYPTO_CBC=m
+ # CONFIG_CRYPTO_CFB is not set
+ CONFIG_CRYPTO_CTR=y
+ # CONFIG_CRYPTO_CTS is not set
+@@ -3801,7 +4381,7 @@ CONFIG_CRC32_SLICEBY8=y
+ # CONFIG_CRC64 is not set
+ # CONFIG_CRC4 is not set
+ # CONFIG_CRC7 is not set
+-# CONFIG_LIBCRC32C is not set
++CONFIG_LIBCRC32C=m
+ # CONFIG_CRC8 is not set
+ CONFIG_XXHASH=y
+ # CONFIG_RANDOM32_SELFTEST is not set
+-- 
+2.43.0
+

--- a/mkimage.sh
+++ b/mkimage.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+
+# Set up variables
+BUILD_DIR="./build"
+CREATE_IMG="sdcard.img"
+
+export DATE=$(date +"%Y%m%d")
+CREATE_IMG="LPI3H_${DATE}.img"
+
+BOOT_SIZE="64M"
+ROOTFS_SIZE="2G"
+IMAGE_SIZE="3072"
+BOOT_PARTITION="${CREATE_IMG}1"
+ROOTFS_PARTITION="${CREATE_IMG}2"
+
+
+# Check if the script is run as root
+if [ "$(id -u)" -ne 0 ]; then
+    echo "This script must be run as root. Please use 'sudo' or log in as root."
+    exit 1
+fi
+
+# Function to convert size to megabytes
+convert_to_mb() {
+    local size=$1
+    local number=${size%[GM]}
+    local unit=${size: -1}
+
+    case "$unit" in
+        G) echo $((number * 1024)) ;;
+        M) echo $number ;;
+        *) echo "Invalid size: $size" >&2; exit 1 ;;
+    esac
+}
+
+# Create an empty image file
+# Convert sizes to megabytes
+BOOT_SIZE_MB=$(convert_to_mb $BOOT_SIZE)
+ROOTFS_SIZE_MB=$(convert_to_mb $ROOTFS_SIZE)
+# Calculate total size in MB for dd command
+TOTAL_SIZE_MB=$((BOOT_SIZE_MB + ROOTFS_SIZE_MB))
+
+dd if=/dev/zero of="$CREATE_IMG" bs=1M count=$IMAGE_SIZE
+
+
+
+# Create partitions using sfdisk (script friendly fdisk)
+# the 2048 is the allocation so we don't ovewrite uboot
+{
+echo label: dos
+echo start=2048, size=+${BOOT_SIZE_MB}M, type=c, bootable
+echo type=83
+} | sudo sfdisk "$CREATE_IMG"
+
+
+# Associate loop devices
+LOOP_DEV=$(losetup -fP --show "$CREATE_IMG")
+if [ -z "$LOOP_DEV" ]; then
+    echo "Failed to associate loop device."
+    exit 1
+fi
+
+
+# Format partitions
+echo "Formatting partitions..."
+
+sudo mkfs.vfat -F 32 -n "boot" "${LOOP_DEV}p1" || { echo "Failed to format boot partition."; exit 1; }
+sudo mkfs.ext4 -t ext4 -F -L "rootfs" "${LOOP_DEV}p2" || { echo "Failed to format rootfs partition."; exit 1; }
+
+echo "flash uboot"
+sudo dd if=$BUILD_DIR/u-boot-sunxi-with-spl.bin of="${LOOP_DEV}" bs=1k seek=8 conv=fsync
+
+
+# Mount partitions
+echo "Mounting partitions..."
+mkdir -p /tmp/{boot,rootfs}
+sudo mount "${LOOP_DEV}p1" /tmp/boot || { echo "Failed to mount boot partition."; exit 1; }
+sudo mount "${LOOP_DEV}p2" /tmp/rootfs || { echo "Failed to mount rootfs partition."; exit 1; }
+
+
+
+# Proceed with partitioning, formatting, and other steps...
+# Copy kernel and device tree files
+# -L to copy symlinks, since vfat filesystems don't support those!
+sudo cp -L  $BUILD_DIR/linux/arch/arm64/boot/Image /tmp/boot
+sudo cp -Lr $BUILD_DIR/linux/arch/arm64/boot/dts /tmp/boot
+
+# Extract root filesystem
+echo "Extracting root filesystem..."
+sudo tar -xpf $BUILD_DIR/rootfs.tar -C /tmp/rootfs
+
+# Unmount partitions
+sudo umount /tmp/{boot,rootfs}
+
+# Detach loop device
+sudo losetup -d "$LOOP_DEV"
+
+echo "finished - copy $CREATE_IMG"
+
+
+# End of script


### PR DESCRIPTION
This is my attempt to solve https://github.com/sipeed/LonganPi-3H-SDK/issues/12

This patch file enables overlayfs, ipv6, br_netfilter, and industrial i/o (modbus) module builds

the basic problem is that this hardware requires a custom kernel, and running `make menuconfig` borks the ` arch/arm64/configs/longanpi_3h_defconfig` file  (even just saving the file with no changes will bork it! due to the patches)

the solution of course is to build yer own patchfile, with ONLY the changes to build the modules you need.
to do this:
```
cd build/linux
git checkout -b break-this
git add  arch/arm64/configs/longanpi_3h_defconfig
git commit -m "working versio"
make menuconfig
# load .. arch/arm64/configs/longanpi_3h_defconfig
# save .. (with no changes)
git checkout -b broken-build-before-config
git add  arch/arm64/configs/longanpi_3h_defconfig
git commit -m "this version is broked"
make menuconfig
# load arch/arm64/configs/longanpi_3h_defconfig
# .. make changes, then save
git add  arch/arm64/configs/longanpi_3h_defconfig
git commit -m "."
git format-patch HEAD -1
# restore your version
git am <filename> .
```


