### PR TITLE
Add support for ephy ac300

### DIFF
--- a/linux/0041-add-ac300-ephy-support-for-linux.patch
+++ b/linux/0041-add-ac300-ephy-support-for-linux.patch
@@ -1,0 +1,68 @@
+From d9be4efdf7092fcec7be862db7116fa752b02ac3 Mon Sep 17 00:00:00 2001
+From: Lu Hui <luhui@sipeed.com>
+Date: Wed, 19 Jun 2024 12:26:58 +0800
+Subject: [PATCH] add-ac300-ephy-support-for-linux
+
+---
+ .../arm64/boot/dts/allwinner/sun50i-h616.dtsi |  7 +++++++
+ .../dts/allwinner/sun50i-h618-longanpi-3h.dts | 19 +++++++++++++++++++
+ 2 files changed, 26 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+index 5f13ac536..c907d8b43 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h616.dtsi
+@@ -229,6 +229,13 @@ pio: pinctrl@300b000 {
+ 			interrupt-controller;
+ 			#interrupt-cells = <3>;
+ 
++			rmii_pins: rmii-pins {
++				pins = "PA0", "PA1", "PA2", "PA3", "PA4",
++				       "PA5", "PA6", "PA7", "PA8", "PA9";
++				function = "emac1";
++				drive-strength = <40>;
++			};
++
+ 			ext_rgmii_pins: rgmii-pins {
+ 				pins = "PI0", "PI1", "PI2", "PI3", "PI4",
+ 				       "PI5", "PI7", "PI8", "PI9", "PI10",
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts b/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
+index 26dc75f20..485559a04 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
++++ b/arch/arm64/boot/dts/allwinner/sun50i-h618-longanpi-3h.dts
+@@ -17,6 +17,7 @@ / {
+ 
+ 	aliases {
+ 		ethernet0 = &emac0;
++		ethernet1 = &emac1;
+ 		serial0 = &uart0;
+ 	};
+ 
+@@ -135,6 +136,24 @@ ext_rgmii_phy: ethernet-phy@1 {
+ 	};
+ };
+ 
++&emac1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rmii_pins>;
++	phy-mode = "rmii";
++	phy-handle = <&ac300_ephy>;
++	phy-supply = <&reg_aldo1>;
++	allwinner,rx-delay-ps = <3100>;
++	allwinner,tx-delay-ps = <700>;
++	status = "okay";
++};
++
++&mdio1 {
++	ac300_ephy: ethernet-phy@10 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <0>;
++	};
++};
++
+ &mmc0 {
+ 	bus-width = <4>;
+ 	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;	/* PF6 */
+-- 
+2.34.1
+

--- a/uboot/0010-add-ac300-ephy-support-for-uboot.patch
+++ b/uboot/0010-add-ac300-ephy-support-for-uboot.patch
@@ -94,9 +94,9 @@ index 4965cbd345..2555da9f9c 100644
 +};
 +
 +&mdio1 {
-+	ac300_ephy: ethernet-phy@1 {
++	ac300_ephy: ethernet-phy@0 {
 +		compatible = "ethernet-phy-ieee802.3-c22";
-+		reg = <1>;
++		reg = <0>;
 +	};
 +};
 +

--- a/uboot/0010-add-ac300-ephy-support-for-uboot.patch
+++ b/uboot/0010-add-ac300-ephy-support-for-uboot.patch
@@ -1,0 +1,285 @@
+From ef110cba80a34ed426e258ea57a97e82639ba9d3 Mon Sep 17 00:00:00 2001
+From: Lu <luhui@sipeed.com>
+Date: Wed, 19 Jun 2024 12:14:49 +0800
+Subject: [PATCH] add ac300 ephy support for uboot
+
+---
+ arch/arm/dts/sun50i-h616.dtsi            | 29 ++++++-
+ arch/arm/dts/sun50i-h618-longanpi-3h.dts | 19 +++++
+ arch/arm/mach-sunxi/clock_sun50i_h6.c    |  6 ++
+ drivers/net/phy/phy.c                    | 98 ++++++++++++++++++++++++
+ drivers/net/sun8i_emac.c                 |  7 ++
+ drivers/pinctrl/sunxi/pinctrl-sunxi.c    |  1 +
+ 6 files changed, 159 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm/dts/sun50i-h616.dtsi b/arch/arm/dts/sun50i-h616.dtsi
+index 74aed0d232..9cbd801784 100644
+--- a/arch/arm/dts/sun50i-h616.dtsi
++++ b/arch/arm/dts/sun50i-h616.dtsi
+@@ -159,6 +159,13 @@
+ 			interrupt-controller;
+ 			#interrupt-cells = <3>;
+ 
++			rmii_pins: rmii-pins {
++				pins = "PA0", "PA1", "PA2", "PA3", "PA4",
++				       "PA5", "PA6", "PA7", "PA8", "PA9";
++				function = "emac1";
++				drive-strength = <40>;
++			};
++
+ 			ext_rgmii_pins: rgmii-pins {
+ 				pins = "PI0", "PI1", "PI2", "PI3", "PI4",
+ 				       "PI5", "PI7", "PI8", "PI9", "PI10",
+@@ -486,7 +493,7 @@
+ 
+ 		emac0: ethernet@5020000 {
+ 			compatible = "allwinner,sun50i-h616-emac0",
+-				     "allwinner,sun50i-a64-emac";
++				     "allwinner,sun50i-h616-emac";
+ 			reg = <0x05020000 0x10000>;
+ 			interrupts = <GIC_SPI 14 IRQ_TYPE_LEVEL_HIGH>;
+ 			interrupt-names = "macirq";
+@@ -504,6 +511,26 @@
+ 			};
+ 		};
+ 
++		emac1: ethernet@5030000 {
++			compatible = "allwinner,sun50i-h616-emac1",
++				     "allwinner,sun50i-h616-emac";
++			reg = <0x05030000 0x10000>;
++			interrupts = <GIC_SPI 15 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "macirq";
++			clocks = <&ccu CLK_BUS_EMAC1>;
++			clock-names = "stmmaceth";
++			resets = <&ccu RST_BUS_EMAC1>;
++			reset-names = "stmmaceth";
++			syscon = <&syscon>;
++			status = "disabled";
++
++			mdio1: mdio {
++				compatible = "snps,dwmac-mdio";
++				#address-cells = <1>;
++				#size-cells = <0>;
++			};
++		};
++
+ 		usbotg: usb@5100000 {
+ 			compatible = "allwinner,sun50i-h616-musb",
+ 				     "allwinner,sun8i-h3-musb";
+diff --git a/arch/arm/dts/sun50i-h618-longanpi-3h.dts b/arch/arm/dts/sun50i-h618-longanpi-3h.dts
+index 4965cbd345..2555da9f9c 100644
+--- a/arch/arm/dts/sun50i-h618-longanpi-3h.dts
++++ b/arch/arm/dts/sun50i-h618-longanpi-3h.dts
+@@ -17,6 +17,7 @@
+ 
+ 	aliases {
+ 		ethernet0 = &emac0;
++		ethernet1 = &emac1;
+ 		serial0 = &uart0;
+ 	};
+ 
+@@ -83,6 +84,24 @@
+ 	};
+ };
+ 
++&emac1 {
++	pinctrl-names = "default";
++	pinctrl-0 = <&rmii_pins>;
++	phy-mode = "rmii";
++	phy-handle = <&ac300_ephy>;
++	phy-supply = <&reg_aldo1>;
++	allwinner,rx-delay-ps = <3100>;
++	allwinner,tx-delay-ps = <700>;
++	status = "okay";
++};
++
++&mdio1 {
++	ac300_ephy: ethernet-phy@1 {
++		compatible = "ethernet-phy-ieee802.3-c22";
++		reg = <1>;
++	};
++};
++
+ &mmc0 {
+ 	bus-width = <4>;
+ 	cd-gpios = <&pio 5 6 GPIO_ACTIVE_HIGH>;	/* PF6 */
+diff --git a/arch/arm/mach-sunxi/clock_sun50i_h6.c b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+index bea91c78bc..8808542bbb 100644
+--- a/arch/arm/mach-sunxi/clock_sun50i_h6.c
++++ b/arch/arm/mach-sunxi/clock_sun50i_h6.c
+@@ -51,6 +51,12 @@ void clock_init_safe(void)
+ 	 * DRAM initialization code.
+ 	 */
+ 	writel(MBUS_CLK_SRC_PLL6X2 | MBUS_CLK_M(3), &ccm->mbus_cfg);
++
++	/* add for pwm ephy */
++	writel(0x10001, 0x030017ac);
++	writel(0x80004, 0x0300a104);
++	writel(0x50, 0x0300a028);
++	writel(0x20, 0x0300a040);
+ }
+ #endif
+ 
+diff --git a/drivers/net/phy/phy.c b/drivers/net/phy/phy.c
+index 63b3e46f10..0cb71d9caf 100644
+--- a/drivers/net/phy/phy.c
++++ b/drivers/net/phy/phy.c
+@@ -18,6 +18,7 @@
+ #include <phy.h>
+ #include <errno.h>
+ #include <asm/global_data.h>
++#include <asm/io.h>
+ #include <dm/of_extra.h>
+ #include <linux/bitops.h>
+ #include <linux/delay.h>
+@@ -28,6 +29,74 @@ DECLARE_GLOBAL_DATA_PTR;
+ 
+ /* Generic PHY support and helper functions */
+ 
++#ifdef CONFIG_MACH_SUN50I_H616
++
++static void disable_intelligent_ieee(struct phy_device *phydev)
++{
++	unsigned int value;
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0100);	/* switch to page 1 */
++	value = phy_read(phydev, MDIO_DEVAD_NONE, 0x17);	/* read address 0 0x17 register */
++	value &= ~(1 << 3);					/* reg 0x17 bit 3, set 0 to disable IEEE */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x17, value);
++	phy_write(phydev, MDIO_DEVAD_NONE,0x1f, 0x0000);	/* switch to page 0 */
++}
++
++static void disable_802_3az_ieee(struct phy_device *phydev)
++{
++	unsigned int value;
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xd, 0x7);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xe, 0x3c);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xd, 0x1 << 14 | 0x7);
++	value = phy_read(phydev, MDIO_DEVAD_NONE, 0xe);
++	value &= ~(0x1 << 1);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xd, 0x7);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xe, 0x3c);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xd, 0x1 << 14 | 0x7);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0xe, value);
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0200);	/* switch to page 2 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x18, 0x0000);
++}
++
++static void ephy_config_default(struct phy_device *phydev)
++{
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0100);	/* Switch to Page 1 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x12, 0x4824);	/* Disable APS */
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0200);	/* Switch to Page 2 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x18, 0x0000);	/* PHYAFE TRX optimization */
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0600);	/* Switch to Page 6 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x14, 0x708b);	/* PHYAFE TX optimization */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x13, 0xF000);	/* PHYAFE RX optimization */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x15, 0x1530);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0800);	/* Switch to Page 6 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x18, 0x00bc);	/* PHYAFE TRX optimization */
++}
++
++static void __maybe_unused ephy_config_fixed(struct phy_device *phydev)
++{
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0100);	/*switch to Page 1 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x12, 0x4824);	/*Disable APS */
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0200);	/*switch to Page 2 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x18, 0x0000);	/*PHYAFE TRX optimization */
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0600);	/*switch to Page 6 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x14, 0x7809);	/*PHYAFE TX optimization */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x13, 0xf000);	/*PHYAFE RX optimization */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x10, 0x5523);
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x15, 0x3533);
++
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0800);	/*switch to Page 8 */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x1d, 0x0844);	/*disable auto offset */
++	phy_write(phydev, MDIO_DEVAD_NONE, 0x18, 0x00bc);	/*PHYAFE TRX optimization */
++}
++
++#endif // CONFIG_MACH_SUN50I_H616
++
+ /**
+  * genphy_config_advert - sanitize and advertise auto-negotiation parameters
+  * @phydev: target phy_device struct
+@@ -432,6 +501,35 @@ int genphy_config(struct phy_device *phydev)
+ 
+ 	genphy_config_aneg(phydev);
+ 
++
++#ifdef CONFIG_MACH_SUN50I_H616
++	val = readl(0x300622c);
++	if (val & (1 << 8)) {
++		phy_write(phydev, MDIO_DEVAD_NONE, 0, 0x1f83);
++		phy_write(phydev, MDIO_DEVAD_NONE, 0, 0x1fb7);
++		phy_write(phydev, MDIO_DEVAD_NONE, 5, 0xa81f);
++		phy_write(phydev, MDIO_DEVAD_NONE, 6, 0);
++		udelay(500000);
++		val = phy_read(phydev, MDIO_DEVAD_NONE, 6);
++		val &= ~(0x0f << 12);
++		val |= (0x0f & (0x03 + (0xffff & val))) << 12;
++		phy_write(phydev, MDIO_DEVAD_NONE, 6, val);
++		if ((0xffff & val) & 0x200) {
++			printf("using AC300 emac1 ephy fixed config ...\n");
++			ephy_config_fixed(phydev);
++		} else {
++			printf("using AC300 emac1 ephy default config ...\n");
++			ephy_config_default(phydev);
++		}
++		disable_intelligent_ieee(phydev);
++		disable_802_3az_ieee(phydev);
++		phy_write(phydev, MDIO_DEVAD_NONE, 0x1f, 0x0000);
++		val = phy_read(phydev, MDIO_DEVAD_NONE, 6);
++		val |= (0x1 << 11);
++		phy_write(phydev, MDIO_DEVAD_NONE, 6, val);
++	}
++#endif // CONFIG_MACH_SUN50I_H616
++
+ 	return 0;
+ }
+ 
+diff --git a/drivers/net/sun8i_emac.c b/drivers/net/sun8i_emac.c
+index 4ba9ee1529..1fb814db98 100644
+--- a/drivers/net/sun8i_emac.c
++++ b/drivers/net/sun8i_emac.c
+@@ -916,6 +916,11 @@ static const struct emac_variant emac_variant_h6 = {
+ 	.support_rmii		= true,
+ };
+ 
++static const struct emac_variant emac_variant_h616 = {
++	.syscon_offset		= 0x34,
++	.support_rmii		= true,
++};
++
+ static const struct udevice_id sun8i_emac_eth_ids[] = {
+ 	{ .compatible = "allwinner,sun8i-a83t-emac",
+ 	  .data = (ulong)&emac_variant_a83t },
+@@ -927,6 +932,8 @@ static const struct udevice_id sun8i_emac_eth_ids[] = {
+ 	  .data = (ulong)&emac_variant_a64 },
+ 	{ .compatible = "allwinner,sun50i-h6-emac",
+ 	  .data = (ulong)&emac_variant_h6 },
++	{ .compatible = "allwinner,sun50i-h616-emac",
++	  .data = (ulong)&emac_variant_h616 },
+ 	{ }
+ };
+ 
+diff --git a/drivers/pinctrl/sunxi/pinctrl-sunxi.c b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+index bdf6360f17..341c05f77e 100644
+--- a/drivers/pinctrl/sunxi/pinctrl-sunxi.c
++++ b/drivers/pinctrl/sunxi/pinctrl-sunxi.c
+@@ -737,6 +737,7 @@ static const struct sunxi_pinctrl_desc __maybe_unused sun50i_h6_r_pinctrl_desc =
+ 
+ static const struct sunxi_pinctrl_function sun50i_h616_pinctrl_functions[] = {
+ 	{ "emac0",	2 },	/* PI0-PI16 */
++	{ "emac1", 2 }, 		/* PA0-PA9 */
+ 	{ "gpio_in",	0 },
+ 	{ "gpio_out",	1 },
+ 	{ "mmc0",	2 },	/* PF0-PF5 */
+-- 
+2.34.1
+


### PR DESCRIPTION
Add basic ephy Support for ac300, init the ac300 in u-boot, and in kernel only needs to enable the pwm5 mux on PA13 at start up